### PR TITLE
Add i18n support for format times

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,4 +1,10 @@
+0.4.0 / 2012-09-13
+==================
 
+  * Multilanguage support [caio-ribeiro-pereira]
+  * add pt-br language [caio-ribeiro-pereira]
+  * add en language (default) [caio-ribeiro-pereira]
+  
 0.3.0 / 2012-09-07
 ==================
 

--- a/README.md
+++ b/README.md
@@ -15,9 +15,14 @@ ms(2 * 60000)         // "2 minutes"
 ms(ms('10 hours'))    // "10 hours"
 ```
 
+```js
+ms(ms('10 horas', 'pt-br')) 	// "10 hours - using pt-br language"
+```
+
 - Node/Browser compatible. Published as `ms` in NPM.
 - If a number is supplied to `ms`, a string with a unit is returned.
 - If a string that contains the number is supplied, it returns it as
 a number (e.g: it returns `100` for `'100'`).
 - If you pass a string with a number and a valid unit, the number of
 equivalent ms is returned.
+- Support multilanguage (i18n) for format ms times.

--- a/index.js
+++ b/index.js
@@ -2,21 +2,28 @@
 /**
  * Helpers.
  */
+// Constants for times array
+var PLURAL = 0;
+var SINGULAR = 1;
+var TINY = 2;
 
 var s = 1000;
 var m = s * 60;
 var h = m * 60;
 var d = h * 24;
+var times = null;
 
 /**
  * Parse or format the given `val`.
  *
  * @param {String|Number} val
+ * @param {String} lang
  * @return {String|Number}
  * @api public
  */
 
-module.exports = function(val){
+module.exports = function(val, lang){
+  times = require('./lang/' + (lang || 'en'));
   if ('string' == typeof val) return parse(val);
   return format(val);
 }
@@ -30,32 +37,34 @@ module.exports = function(val){
  */
 
 function parse(str) {
-  var m = /^((?:\d+)?\.?\d+) *(ms|seconds?|s|minutes?|m|hours?|h|days?|d|years?|y)?$/i.exec(str);
+  var m = times.regex.exec(str);
   if (!m) return;
   var n = parseFloat(m[1]);
   var type = (m[2] || 'ms').toLowerCase();
   switch (type) {
-    case 'years':
-    case 'year':
-    case 'y':
+    case times.years[PLURAL]:
+    case times.years[SINGULAR]:
+    case times.years[TINY]:
       return n * 31557600000;
-    case 'days':
-    case 'day':
-    case 'd':
+    case times.days[PLURAL]:
+    case times.days[SINGULAR]:
+    case times.days[TINY]:
       return n * 86400000;
-    case 'hours':
-    case 'hour':
-    case 'h':
+    case times.hours[PLURAL]:
+    case times.hours[SINGULAR]:
+    case times.hours[TINY]:
       return n * 3600000;
-    case 'minutes':
-    case 'minute':
-    case 'm':
+    case times.minutes[PLURAL]:
+    case times.minutes[SINGULAR]:
+    case times.minutes[TINY]:
       return n * 60000;
-    case 'seconds':
-    case 'second':
-    case 's':
+    case times.seconds[PLURAL]:
+    case times.seconds[SINGULAR]:
+    case times.seconds[TINY]:
       return n * 1000;
-    case 'ms':
+    case times.miliseconds[PLURAL]:
+    case times.miliseconds[SINGULAR]:
+    case times.miliseconds[TINY]:
       return n;
   }
 }
@@ -69,13 +78,13 @@ function parse(str) {
  */
 
 function format(ms) {
-  if (ms == d) return (ms / d) + ' day';
-  if (ms > d) return (ms / d) + ' days';
-  if (ms == h) return (ms / h) + ' hour';
-  if (ms > h) return (ms / h) + ' hours';
-  if (ms == m) return (ms / m) + ' minute';
-  if (ms > m) return (ms / m) + ' minutes';
-  if (ms == s) return (ms / s) + ' second';
-  if (ms > s) return (ms / s) + ' seconds';
-  return ms + ' ms';
+  if (ms == d) return (ms / d) + ' ' + times.days[SINGULAR];
+  if (ms > d) return (ms / d) + ' ' + times.days[PLURAL];
+  if (ms == h) return (ms / h) + ' ' + times.hours[SINGULAR];
+  if (ms > h) return (ms / h) + ' ' + times.hours[PLURAL];
+  if (ms == m) return (ms / m) + ' ' + times.minutes[SINGULAR];
+  if (ms > m) return (ms / m) + ' ' + times.minutes[PLURAL];
+  if (ms == s) return (ms / s) + ' ' + times.seconds[SINGULAR];
+  if (ms > s) return (ms / s) + ' ' + times.seconds[PLURAL];
+  return ms + ' ' + times.miliseconds[TINY];
 }

--- a/lang/en.js
+++ b/lang/en.js
@@ -1,0 +1,8 @@
+// EN Default Language support - By Caio Ribeiro Pereira
+module.exports.years = ['years','year','y'];
+module.exports.days  = ['days','day','d'];
+module.exports.hours = ['hours', 'hour', 'h'];
+module.exports.minutes = ['minutes', 'minute', 'm'];
+module.exports.seconds = ['seconds', 'second', 's'];
+module.exports.miliseconds = ['miliseconds','milisecond','ms'];
+module.exports.regex = /^((?:\d+)?\.?\d+) *(ms|miliseconds?|seconds?|s|minutes?|m|hours?|h|days?|d|years?|y)?$/i;

--- a/lang/pt-br.js
+++ b/lang/pt-br.js
@@ -1,0 +1,8 @@
+// PT-BR Language support - By Caio Ribeiro Pereira
+module.exports.years = ['anos','ano','a'];
+module.exports.days  = ['dias','dia','d'];
+module.exports.hours = ['horas', 'hora', 'h'];
+module.exports.minutes = ['minutos', 'minuto', 'm'];
+module.exports.seconds = ['segundos', 'segundo', 's'];
+module.exports.miliseconds = ['milisegundos','milisegundo','ms'];
+module.exports.regex = /^((?:\d+)?\.?\d+) *(ms|milisegundos?|segundos?|s|minutos?|m|horas?|h|dias?|d|anos?|a)?$/i;	

--- a/package.json
+++ b/package.json
@@ -1,7 +1,10 @@
 {
     "name": "ms"
-  , "version": "0.3.0"
+  , "version": "0.4.0"
   , "description": "Tiny ms conversion utility"
+  , "contributors": [ 
+       { "name": "Caio Ribeiro Pereira", "email": "caio.ribeiro.pereira@gmail.com" }
+    ]
   , "main": "./index"
   , "devDependencies": {
         "mocha": "*"

--- a/test/test.js
+++ b/test/test.js
@@ -8,7 +8,7 @@ if ('undefined' != typeof require) {
   ms = require('../');
 }
 
-// strings
+// Default lang strings
 
 describe('ms(string)', function(){
   it('should preserve ms', function () {
@@ -52,7 +52,7 @@ describe('ms(string)', function(){
   });
 })
 
-// numbers
+// Default lang numbers
 
 describe('ms(number)', function(){
   it('should support milliseconds', function(){
@@ -81,5 +81,37 @@ describe('ms(number)', function(){
     expect(ms(24 * 60 * 60 * 1000)).to.be('1 day');
     expect(ms(24 * 60 * 60 * 1500)).to.be('1.5 days');
     expect(ms(24 * 60 * 60 * 10000)).to.be('10 days');
+  })
+})
+
+// pt-br lang numbers
+
+describe('ms(number)', function(){
+  it('deve suportar milisegundos', function(){
+    expect(ms(500, 'pt-br')).to.be('500 ms');
+  })
+
+  it('deve suportar segundos', function(){
+    expect(ms(1000,'pt-br')).to.be('1 segundo');
+    expect(ms(1500,'pt-br')).to.be('1.5 segundos');
+    expect(ms(10000,'pt-br')).to.be('10 segundos');
+  })
+
+  it('deve suportar minutos', function(){
+    expect(ms(60 * 1000,'pt-br')).to.be('1 minuto');
+    expect(ms(60 * 1500,'pt-br')).to.be('1.5 minutos');
+    expect(ms(60 * 10000,'pt-br')).to.be('10 minutos');
+  })
+
+  it('deve suportar horas', function(){
+    expect(ms(60 * 60 * 1000,'pt-br')).to.be('1 hora');
+    expect(ms(60 * 60 * 1500,'pt-br')).to.be('1.5 horas');
+    expect(ms(60 * 60 * 10000,'pt-br')).to.be('10 horas');
+  })
+
+  it('deve suportar dias', function(){
+    expect(ms(24 * 60 * 60 * 1000,'pt-br')).to.be('1 dia');
+    expect(ms(24 * 60 * 60 * 1500,'pt-br')).to.be('1.5 dias');
+    expect(ms(24 * 60 * 60 * 10000,'pt-br')).to.be('10 dias');
   })
 })


### PR DESCRIPTION
Hi, I enjoy so much this module and I would like to pull request this new feature for you

Initially ms supports just en and pt-br languages, and you can use the default mode too:

```js
ms('1d') // Default support (English)

ms('1 dia', 'pt-br') // PT-BR support (Brazilian Portuguese)
```