### PR TITLE
throw an error if the val is invalid

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,16 +17,23 @@ var y = d * 365.25;
  *
  * @param {String|Number} val
  * @param {Object} options
+ * @throws {Error} throw an error if val is not a non-empty string or a number
  * @return {String|Number}
  * @api public
  */
 
 module.exports = function(val, options){
   options = options || {};
-  if ('string' == typeof val) return parse(val);
-  return options['long']
-    ? fmtLong(val)
-    : fmtShort(val);
+  var type = typeof val;
+  if ('string' === type && val.length > 0) {
+    return parse(val);
+  } else if ('number' === type && isNaN(val) === false) {
+    return options['long']
+      ? fmtLong(val)
+      : fmtShort(val);
+  } else {
+    throw new Error('val is not a non-empty string or a valid number. val=' + JSON.stringify(val));
+  }
 };
 
 /**

--- a/test/index.js
+++ b/test/index.js
@@ -11,6 +11,12 @@ if ('undefined' != typeof require) {
 // strings
 
 describe('ms(string)', function(){
+  it('should not throw an error', function() {
+    expect(function() {
+      ms('1m');
+    }).to.not.throwError();
+  });
+
   it('should preserve ms', function () {
     expect(ms('100')).to.be(100);
   });
@@ -59,6 +65,12 @@ describe('ms(string)', function(){
 // long strings
 
 describe('ms(long string)', function(){
+  it('should not throw an error', function() {
+    expect(function() {
+      ms('53 milliseconds');
+    }).to.not.throwError();
+  });
+
   it('should convert milliseconds to ms', function () {
     expect(ms('53 milliseconds')).to.be(53);
   });
@@ -91,6 +103,12 @@ describe('ms(long string)', function(){
 // numbers
 
 describe('ms(number, { long: true })', function(){
+  it('should not throw an error', function() {
+    expect(function() {
+      ms(500, { long: true });
+    }).to.not.throwError();
+  });
+
   it('should support milliseconds', function(){
     expect(ms(500, { long: true })).to.be('500 ms');
   })
@@ -127,6 +145,12 @@ describe('ms(number, { long: true })', function(){
 // numbers
 
 describe('ms(number)', function(){
+  it('should not throw an error', function() {
+    expect(function() {
+      ms(500);
+    }).to.not.throwError();
+  });
+
   it('should support milliseconds', function(){
     expect(ms(500)).to.be('500ms');
   })
@@ -155,3 +179,44 @@ describe('ms(number)', function(){
     expect(ms(234234234)).to.be('3d');
   })
 })
+
+
+// invalid inputs
+
+describe('ms(invalid inputs)', function() {
+  it('should throw an error, when ms("")', function() {
+    expect(function() {
+      ms('');
+    }).to.throwError();
+  });
+
+  it('should throw an error, when ms(undefined)', function() {
+    expect(function() {
+      ms(undefined);
+    }).to.throwError();
+  });
+
+  it('should throw an error, when ms(null)', function() {
+    expect(function() {
+      ms(null);
+    }).to.throwError();
+  });
+
+  it('should throw an error, when ms([])', function() {
+    expect(function() {
+      ms([]);
+    }).to.throwError();
+  });
+
+  it('should throw an error, when ms({})', function() {
+    expect(function() {
+      ms({});
+    }).to.throwError();
+  });
+
+  it('should throw an error, when ms(NaN)', function() {
+    expect(function() {
+      ms(NaN);
+    }).to.throwError();
+  });
+});


### PR DESCRIPTION
Give an error response to developers immediately, when calling `ms(null)` or `ms(undefined)` or other invalid things.
It can help developers avoid mistakes, and less debug.