### PR TITLE
Add `xo` as a linting tool

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,11 +2,11 @@
  * Helpers.
  */
 
-var s = 1000;
-var m = s * 60;
-var h = m * 60;
-var d = h * 24;
-var y = d * 365.25;
+var s = 1000
+var m = s * 60
+var h = m * 60
+var d = h * 24
+var y = d * 365.25
 
 /**
  * Parse or format the given `val`.
@@ -22,19 +22,18 @@ var y = d * 365.25;
  * @api public
  */
 
-module.exports = function(val, options){
-  options = options || {};
-  var type = typeof val;
-  if ('string' === type && val.length > 0) {
-    return parse(val);
-  } else if ('number' === type && isNaN(val) === false) {
-    return options['long']
-      ? fmtLong(val)
-      : fmtShort(val);
-  } else {
-    throw new Error('val is not a non-empty string or a valid number. val=' + JSON.stringify(val));
+module.exports = function (val, options) {
+  options = options || {}
+  var type = typeof val
+  if (type === 'string' && val.length > 0) {
+    return parse(val)
+  } else if (type === 'number' && isNaN(val) === false) {
+    return options.long ?
+			fmtLong(val) :
+			fmtShort(val)
   }
-};
+  throw new Error('val is not a non-empty string or a valid number. val=' + JSON.stringify(val))
+}
 
 /**
  * Parse the given `str` and return milliseconds.
@@ -45,47 +44,53 @@ module.exports = function(val, options){
  */
 
 function parse(str) {
-  str = '' + str;
-  if (str.length > 10000) return;
-  var match = /^((?:\d+)?\.?\d+) *(milliseconds?|msecs?|ms|seconds?|secs?|s|minutes?|mins?|m|hours?|hrs?|h|days?|d|years?|yrs?|y)?$/i.exec(str);
-  if (!match) return;
-  var n = parseFloat(match[1]);
-  var type = (match[2] || 'ms').toLowerCase();
+  str = String(str)
+  if (str.length > 10000) {
+    return
+  }
+  var match = /^((?:\d+)?\.?\d+) *(milliseconds?|msecs?|ms|seconds?|secs?|s|minutes?|mins?|m|hours?|hrs?|h|days?|d|years?|yrs?|y)?$/i.exec(str)
+  if (!match) {
+    return
+  }
+  var n = parseFloat(match[1])
+  var type = (match[2] || 'ms').toLowerCase()
   switch (type) {
     case 'years':
     case 'year':
     case 'yrs':
     case 'yr':
     case 'y':
-      return n * y;
+      return n * y
     case 'days':
     case 'day':
     case 'd':
-      return n * d;
+      return n * d
     case 'hours':
     case 'hour':
     case 'hrs':
     case 'hr':
     case 'h':
-      return n * h;
+      return n * h
     case 'minutes':
     case 'minute':
     case 'mins':
     case 'min':
     case 'm':
-      return n * m;
+      return n * m
     case 'seconds':
     case 'second':
     case 'secs':
     case 'sec':
     case 's':
-      return n * s;
+      return n * s
     case 'milliseconds':
     case 'millisecond':
     case 'msecs':
     case 'msec':
     case 'ms':
-      return n;
+      return n
+    default:
+      return undefined
   }
 }
 
@@ -98,11 +103,19 @@ function parse(str) {
  */
 
 function fmtShort(ms) {
-  if (ms >= d) return Math.round(ms / d) + 'd';
-  if (ms >= h) return Math.round(ms / h) + 'h';
-  if (ms >= m) return Math.round(ms / m) + 'm';
-  if (ms >= s) return Math.round(ms / s) + 's';
-  return ms + 'ms';
+  if (ms >= d) {
+    return Math.round(ms / d) + 'd'
+  }
+  if (ms >= h) {
+    return Math.round(ms / h) + 'h'
+  }
+  if (ms >= m) {
+    return Math.round(ms / m) + 'm'
+  }
+  if (ms >= s) {
+    return Math.round(ms / s) + 's'
+  }
+  return ms + 'ms'
 }
 
 /**
@@ -114,11 +127,11 @@ function fmtShort(ms) {
  */
 
 function fmtLong(ms) {
-  return plural(ms, d, 'day')
-    || plural(ms, h, 'hour')
-    || plural(ms, m, 'minute')
-    || plural(ms, s, 'second')
-    || ms + ' ms';
+  return plural(ms, d, 'day') ||
+    plural(ms, h, 'hour') ||
+    plural(ms, m, 'minute') ||
+    plural(ms, s, 'second') ||
+    ms + ' ms'
 }
 
 /**
@@ -126,7 +139,11 @@ function fmtLong(ms) {
  */
 
 function plural(ms, n, name) {
-  if (ms < n) return;
-  if (ms < n * 1.5) return Math.floor(ms / n) + ' ' + name;
-  return Math.ceil(ms / n) + ' ' + name + 's';
+  if (ms < n) {
+    return
+  }
+  if (ms < n * 1.5) {
+    return Math.floor(ms / n) + ' ' + name
+  }
+  return Math.ceil(ms / n) + ' ' + name + 's'
 }

--- a/package.json
+++ b/package.json
@@ -8,18 +8,26 @@
     "index.js"
   ],
   "scripts": {
-    "test": "mocha test/index.js",
+    "test": "xo && mocha test/index.js",
     "test-browser": "serve ./test"
   },
   "license": "MIT",
   "devDependencies": {
-    "mocha": "^3.0.2",
     "expect.js": "^0.3.1",
-    "serve": "^1.4.0"
+    "mocha": "^3.0.2",
+    "serve": "^1.4.0",
+    "xo": "^0.17.0"
   },
   "component": {
     "scripts": {
       "ms/index.js": "index.js"
     }
+  },
+  "xo": {
+    "space": true,
+    "semicolon": false,
+    "envs": [
+      "mocha"
+    ]
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,222 +1,221 @@
-
+/* eslint-disable no-undef */
 /**
  * Dependencies.
  */
 
-if ('undefined' != typeof require) {
-  expect = require('expect.js');
-  ms = require('../');
+if (typeof require !== 'undefined') {
+  expect = require('expect.js')
+  ms = require('../')
 }
 
 // strings
 
-describe('ms(string)', function(){
-  it('should not throw an error', function() {
-    expect(function() {
-      ms('1m');
-    }).to.not.throwError();
-  });
+describe('ms(string)', function () {
+  it('should not throw an error', function () {
+    expect(function () {
+      ms('1m')
+    }).to.not.throwError()
+  })
 
   it('should preserve ms', function () {
-    expect(ms('100')).to.be(100);
-  });
+    expect(ms('100')).to.be(100)
+  })
 
   it('should convert from m to ms', function () {
-    expect(ms('1m')).to.be(60000);
-  });
+    expect(ms('1m')).to.be(60000)
+  })
 
   it('should convert from h to ms', function () {
-    expect(ms('1h')).to.be(3600000);
-  });
+    expect(ms('1h')).to.be(3600000)
+  })
 
   it('should convert d to ms', function () {
-    expect(ms('2d')).to.be(172800000);
-  });
+    expect(ms('2d')).to.be(172800000)
+  })
 
   it('should convert s to ms', function () {
-    expect(ms('1s')).to.be(1000);
-  });
+    expect(ms('1s')).to.be(1000)
+  })
 
   it('should convert ms to ms', function () {
-    expect(ms('100ms')).to.be(100);
-  });
+    expect(ms('100ms')).to.be(100)
+  })
 
   it('should work with decimals', function () {
-    expect(ms('1.5h')).to.be(5400000);
-  });
+    expect(ms('1.5h')).to.be(5400000)
+  })
 
   it('should work with multiple spaces', function () {
-    expect(ms('1   s')).to.be(1000);
-  });
+    expect(ms('1   s')).to.be(1000)
+  })
 
   it('should return NaN if invalid', function () {
-    expect(isNaN(ms('☃'))).to.be(true);
-  });
+    expect(isNaN(ms('☃'))).to.be(true)
+  })
 
   it('should be case-insensitive', function () {
-    expect(ms('1.5H')).to.be(5400000);
-  });
+    expect(ms('1.5H')).to.be(5400000)
+  })
 
   it('should work with numbers starting with .', function () {
-    expect(ms('.5ms')).to.be(.5);
-  });
+    expect(ms('.5ms')).to.be(0.5)
+  })
 })
 
 // long strings
 
-describe('ms(long string)', function(){
-  it('should not throw an error', function() {
-    expect(function() {
-      ms('53 milliseconds');
-    }).to.not.throwError();
-  });
+describe('ms(long string)', function () {
+  it('should not throw an error', function () {
+    expect(function () {
+      ms('53 milliseconds')
+    }).to.not.throwError()
+  })
 
   it('should convert milliseconds to ms', function () {
-    expect(ms('53 milliseconds')).to.be(53);
-  });
+    expect(ms('53 milliseconds')).to.be(53)
+  })
 
   it('should convert msecs to ms', function () {
-    expect(ms('17 msecs')).to.be(17);
-  });
+    expect(ms('17 msecs')).to.be(17)
+  })
 
   it('should convert sec to ms', function () {
-    expect(ms('1 sec')).to.be(1000);
-  });
+    expect(ms('1 sec')).to.be(1000)
+  })
 
   it('should convert from min to ms', function () {
-    expect(ms('1 min')).to.be(60000);
-  });
+    expect(ms('1 min')).to.be(60000)
+  })
 
   it('should convert from hr to ms', function () {
-    expect(ms('1 hr')).to.be(3600000);
-  });
+    expect(ms('1 hr')).to.be(3600000)
+  })
 
   it('should convert days to ms', function () {
-    expect(ms('2 days')).to.be(172800000);
-  });
+    expect(ms('2 days')).to.be(172800000)
+  })
 
   it('should work with decimals', function () {
-    expect(ms('1.5 hours')).to.be(5400000);
-  });
-})
-
-// numbers
-
-describe('ms(number, { long: true })', function(){
-  it('should not throw an error', function() {
-    expect(function() {
-      ms(500, { long: true });
-    }).to.not.throwError();
-  });
-
-  it('should support milliseconds', function(){
-    expect(ms(500, { long: true })).to.be('500 ms');
-  })
-
-  it('should support seconds', function(){
-    expect(ms(1000, { long: true })).to.be('1 second');
-    expect(ms(1200, { long: true })).to.be('1 second');
-    expect(ms(10000, { long: true })).to.be('10 seconds');
-  })
-
-  it('should support minutes', function(){
-    expect(ms(60 * 1000, { long: true })).to.be('1 minute');
-    expect(ms(60 * 1200, { long: true })).to.be('1 minute');
-    expect(ms(60 * 10000, { long: true })).to.be('10 minutes');
-  })
-
-  it('should support hours', function(){
-    expect(ms(60 * 60 * 1000, { long: true })).to.be('1 hour');
-    expect(ms(60 * 60 * 1200, { long: true })).to.be('1 hour');
-    expect(ms(60 * 60 * 10000, { long: true })).to.be('10 hours');
-  })
-
-  it('should support days', function(){
-    expect(ms(24 * 60 * 60 * 1000, { long: true })).to.be('1 day');
-    expect(ms(24 * 60 * 60 * 1200, { long: true })).to.be('1 day');
-    expect(ms(24 * 60 * 60 * 10000, { long: true })).to.be('10 days');
-  })
-
-  it('should round', function(){
-    expect(ms(234234234, { long: true })).to.be('3 days');
+    expect(ms('1.5 hours')).to.be(5400000)
   })
 })
 
 // numbers
 
-describe('ms(number)', function(){
-  it('should not throw an error', function() {
-    expect(function() {
-      ms(500);
-    }).to.not.throwError();
-  });
-
-  it('should support milliseconds', function(){
-    expect(ms(500)).to.be('500ms');
+describe('ms(number, { long: true })', function () {
+  it('should not throw an error', function () {
+    expect(function () {
+      ms(500, {long: true})
+    }).to.not.throwError()
   })
 
-  it('should support seconds', function(){
-    expect(ms(1000)).to.be('1s');
-    expect(ms(10000)).to.be('10s');
+  it('should support milliseconds', function () {
+    expect(ms(500, {long: true})).to.be('500 ms')
   })
 
-  it('should support minutes', function(){
-    expect(ms(60 * 1000)).to.be('1m');
-    expect(ms(60 * 10000)).to.be('10m');
+  it('should support seconds', function () {
+    expect(ms(1000, {long: true})).to.be('1 second')
+    expect(ms(1200, {long: true})).to.be('1 second')
+    expect(ms(10000, {long: true})).to.be('10 seconds')
   })
 
-  it('should support hours', function(){
-    expect(ms(60 * 60 * 1000)).to.be('1h');
-    expect(ms(60 * 60 * 10000)).to.be('10h');
+  it('should support minutes', function () {
+    expect(ms(60 * 1000, {long: true})).to.be('1 minute')
+    expect(ms(60 * 1200, {long: true})).to.be('1 minute')
+    expect(ms(60 * 10000, {long: true})).to.be('10 minutes')
   })
 
-  it('should support days', function(){
-    expect(ms(24 * 60 * 60 * 1000)).to.be('1d');
-    expect(ms(24 * 60 * 60 * 10000)).to.be('10d');
+  it('should support hours', function () {
+    expect(ms(60 * 60 * 1000, {long: true})).to.be('1 hour')
+    expect(ms(60 * 60 * 1200, {long: true})).to.be('1 hour')
+    expect(ms(60 * 60 * 10000, {long: true})).to.be('10 hours')
   })
 
-  it('should round', function(){
-    expect(ms(234234234)).to.be('3d');
+  it('should support days', function () {
+    expect(ms(24 * 60 * 60 * 1000, {long: true})).to.be('1 day')
+    expect(ms(24 * 60 * 60 * 1200, {long: true})).to.be('1 day')
+    expect(ms(24 * 60 * 60 * 10000, {long: true})).to.be('10 days')
+  })
+
+  it('should round', function () {
+    expect(ms(234234234, {long: true})).to.be('3 days')
   })
 })
 
+// numbers
+
+describe('ms(number)', function () {
+  it('should not throw an error', function () {
+    expect(function () {
+      ms(500)
+    }).to.not.throwError()
+  })
+
+  it('should support milliseconds', function () {
+    expect(ms(500)).to.be('500ms')
+  })
+
+  it('should support seconds', function () {
+    expect(ms(1000)).to.be('1s')
+    expect(ms(10000)).to.be('10s')
+  })
+
+  it('should support minutes', function () {
+    expect(ms(60 * 1000)).to.be('1m')
+    expect(ms(60 * 10000)).to.be('10m')
+  })
+
+  it('should support hours', function () {
+    expect(ms(60 * 60 * 1000)).to.be('1h')
+    expect(ms(60 * 60 * 10000)).to.be('10h')
+  })
+
+  it('should support days', function () {
+    expect(ms(24 * 60 * 60 * 1000)).to.be('1d')
+    expect(ms(24 * 60 * 60 * 10000)).to.be('10d')
+  })
+
+  it('should round', function () {
+    expect(ms(234234234)).to.be('3d')
+  })
+})
 
 // invalid inputs
 
-describe('ms(invalid inputs)', function() {
-  it('should throw an error, when ms("")', function() {
-    expect(function() {
-      ms('');
-    }).to.throwError();
-  });
+describe('ms(invalid inputs)', function () {
+  it('should throw an error, when ms("")', function () {
+    expect(function () {
+      ms('')
+    }).to.throwError()
+  })
 
-  it('should throw an error, when ms(undefined)', function() {
-    expect(function() {
-      ms(undefined);
-    }).to.throwError();
-  });
+  it('should throw an error, when ms(undefined)', function () {
+    expect(function () {
+      ms(undefined)
+    }).to.throwError()
+  })
 
-  it('should throw an error, when ms(null)', function() {
-    expect(function() {
-      ms(null);
-    }).to.throwError();
-  });
+  it('should throw an error, when ms(null)', function () {
+    expect(function () {
+      ms(null)
+    }).to.throwError()
+  })
 
-  it('should throw an error, when ms([])', function() {
-    expect(function() {
-      ms([]);
-    }).to.throwError();
-  });
+  it('should throw an error, when ms([])', function () {
+    expect(function () {
+      ms([])
+    }).to.throwError()
+  })
 
-  it('should throw an error, when ms({})', function() {
-    expect(function() {
-      ms({});
-    }).to.throwError();
-  });
+  it('should throw an error, when ms({})', function () {
+    expect(function () {
+      ms({})
+    }).to.throwError()
+  })
 
-  it('should throw an error, when ms(NaN)', function() {
-    expect(function() {
-      ms(NaN);
-    }).to.throwError();
-  });
-});
+  it('should throw an error, when ms(NaN)', function () {
+    expect(function () {
+      ms(NaN)
+    }).to.throwError()
+  })
+})


### PR DESCRIPTION
This adds XO as a linting tool to have a consistent linter and style accross the Zeit projects, as requested by @leo.