### PR TITLE
Mark "options" param as optional in jsdoc

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ var y = d * 365.25
  *  - `long` verbose formatting [false]
  *
  * @param {String|Number} val
- * @param {Object} options
+ * @param {Object} [options]
  * @throws {Error} throw an error if val is not a non-empty string or a number
  * @return {String|Number}
  * @api public


### PR DESCRIPTION
Without it some IDE/editors show message "Invalid number of arguments, expected 2" when using

```js
ms('1 day')
```