### PR TITLE
Feature proposal: microseconds and nanoseconds support

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,8 @@
  * Helpers.
  */
 
+var ns = 1e-6;
+var μs = 1e-3;
 var s = 1000;
 var m = s * 60;
 var h = m * 60;
@@ -49,7 +51,7 @@ function parse(str) {
   if (str.length > 10000) {
     return;
   }
-  var match = /^((?:\d+)?\.?\d+) *(milliseconds?|msecs?|ms|seconds?|secs?|s|minutes?|mins?|m|hours?|hrs?|h|days?|d|years?|yrs?|y)?$/i.exec(
+  var match = /^((?:\d+)?\.?\d+) *(nanoseconds?|nanos?|nsecs?|ns|microseconds?|micros?|μs|milliseconds?|msecs?|ms|seconds?|secs?|s|minutes?|mins?|m|hours?|hrs?|h|days?|d|years?|yrs?|y)?$/i.exec(
     str
   );
   if (!match) {
@@ -92,6 +94,20 @@ function parse(str) {
     case 'msec':
     case 'ms':
       return n;
+    case 'microseconds':
+    case 'microsecond':
+    case 'micros':
+    case 'micro':
+    case 'μs':
+      return n * μs;
+    case 'nanoseconds':
+    case 'nanosecond':
+    case 'nanos':
+    case 'nano':
+    case 'nsecs':
+    case 'nsec':
+    case 'ns':
+      return n * ns;
     default:
       return undefined;
   }
@@ -118,7 +134,14 @@ function fmtShort(ms) {
   if (ms >= s) {
     return Math.round(ms / s) + 's';
   }
-  return ms + 'ms';
+  if (ms >= 1) {
+    return ms + 'ms';
+  }
+  if (ms >= μs) {
+    return Math.round(ms / μs) + 'μs';
+  }
+
+  return Math.round(ms / ns) + 'ns';
 }
 
 /**
@@ -134,7 +157,9 @@ function fmtLong(ms) {
     plural(ms, h, 'hour') ||
     plural(ms, m, 'minute') ||
     plural(ms, s, 'second') ||
-    ms + ' ms';
+    (ms < 1 ? undefined : ms + ' ms') || // should probably be "plural(ms, 1, 'millisecond') ||"
+    plural(ms, μs, 'microsecond') ||
+    ms / ns + ' ns';
 }
 
 /**

--- a/readme.md
+++ b/readme.md
@@ -17,11 +17,14 @@ ms('1m')      // 60000
 ms('5s')      // 5000
 ms('1y')      // 31557600000
 ms('100')     // 100
+ms('23μs')    // 0.023
+ms('386ns')   // 0.000386
 ```
 
 ### Convert from milliseconds
 
 ```js
+ms(2e-2)              // "20μs"
 ms(60000)             // "1m"
 ms(2 * 60000)         // "2m"
 ms(ms('10 hours'))    // "10h"
@@ -30,6 +33,7 @@ ms(ms('10 hours'))    // "10h"
 ### Time format written-out
 
 ```js
+ms(2e-2, { long: true })              // "20 microseconds"
 ms(60000, { long: true })             // "1 minute"
 ms(2 * 60000, { long: true })         // "2 minutes"
 ms(ms('10 hours'), { long: true })    // "10 hours"

--- a/tests.js
+++ b/tests.js
@@ -41,6 +41,14 @@ describe('ms(string)', function() {
     expect(ms('100ms')).to.be(100);
   });
 
+  it('should convert μs to ms', function() {
+    expect(ms('1μs')).to.be(0.001);
+  });
+
+  it('should convert ns to ms', function() {
+    expect(ms('1ns')).to.be(0.000001);
+  });
+
   it('should work with decimals', function() {
     expect(ms('1.5h')).to.be(5400000);
   });
@@ -69,6 +77,14 @@ describe('ms(long string)', function() {
     expect(function() {
       ms('53 milliseconds');
     }).to.not.throwError();
+  });
+
+  it('should convert nanoseconds to ms', function() {
+    expect(ms('42 nanoseconds')).to.be(4.2e-5);
+  });
+
+  it('should convert microseconds to ms', function() {
+    expect(ms('66 microseconds')).to.be(0.066);
   });
 
   it('should convert milliseconds to ms', function() {
@@ -107,6 +123,16 @@ describe('ms(number, { long: true })', function() {
     expect(function() {
       ms(500, { long: true });
     }).to.not.throwError();
+  });
+
+  it('should support nanoseconds', function() {
+    expect(ms(998e-6, { long: true })).to.be('998 ns');
+  });
+
+  it('should support microseconds', function() {
+    expect(ms(1e-3, { long: true })).to.be('1 microsecond');
+    expect(ms(12e-4, { long: true })).to.be('1 microsecond');
+    expect(ms(10e-3, { long: true })).to.be('10 microseconds');
   });
 
   it('should support milliseconds', function() {
@@ -149,6 +175,14 @@ describe('ms(number)', function() {
     expect(function() {
       ms(500);
     }).to.not.throwError();
+  });
+
+  it('should support microseconds', function() {
+    expect(ms(13e-3)).to.be('13μs');
+  });
+
+  it('should support nanoseconds', function() {
+    expect(ms(500e-6)).to.be('500ns');
   });
 
   it('should support milliseconds', function() {


### PR DESCRIPTION
Hi!

I've a need for support of microseconds and nanoseconds, and I thought I would propose a pull request on this module (w/ updated unit tests and readme).

The only doubt I have is when converting to long format. I left a comment line 160 about this: when the module converts to milliseconds, I decided to keep the `xxx ms` format instead of changing it to `xxx millisecond(s)`, to avoid introducing a breaking change.
Should you agree with adding micros and nanos to `ms`, you may have a different opinion on this one. If so just tell me, I will gladly proceed to change this.

