### PR TITLE
Limit str to 100 to avoid ReDoS of 0.3s

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ module.exports = function(val, options) {
 
 function parse(str) {
   str = String(str);
-  if (str.length > 10000) {
+  if (str.length > 100) {
     return;
   }
   var match = /^((?:\d+)?\.?\d+) *(milliseconds?|msecs?|ms|seconds?|secs?|s|minutes?|mins?|m|hours?|hrs?|h|days?|d|years?|yrs?|y)?$/i.exec(


### PR DESCRIPTION
Hey,
The fix for CVE-2015-8315 was incomplete. Limiting the input to 10,000 chars reduced the risk significantly but it is still possible to cause a delay of 0.3s. Suggested to limit it to 100 chars as there is no reason for a date to be over that :)

PoC:
```js
ms=require('ms');
ms('1'.repeat(9998) + 'Q')
//Takes about ~0.3s
```

Thanks,
Karen Yavine
Security Analyst @ [snyk.io](https://snyk.io/)