### PR TITLE
Improve performance and remove str limit

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,9 +50,7 @@ function parse(str) {
   if (str.length > 100) {
     return;
   }
-  var match = /^((?:\d+)?\-?\d?\.?\d+) *(milliseconds?|msecs?|ms|seconds?|secs?|s|minutes?|mins?|m|hours?|hrs?|h|days?|d|weeks?|w|years?|yrs?|y)?$/i.exec(
-    str
-  );
+  var match = /^(-?(?:\d+)?\.?\d+) *(\w*)$/i.exec(str);
   if (!match) {
     return;
   }


### PR DESCRIPTION
Changing the Regex from:
 `/^((?:\d+)?\.?\d+) *(milliseconds?|msecs?|ms|seconds?|secs?|s|minutes?|mins?|m|hours?|hrs?|h|days?|d|years?|yrs?|y)?$/i`
to:
`/^((?:\d+)?\.?\d+) *(\w{0,12})?$/i`
seems to produce better performance and solve the issues with long str.

[Benchmark source](https://gist.github.com/thevtm/063a834083a42af535e26196a5d3c8d5)

```
original x 38,472 ops/sec ±2.05% (88 runs sampled)
mine x 74,820 ops/sec ±1.84% (84 runs sampled)
Fastest is mine
Done in 17.97s.
```