### PR TITLE
Add reference to ms.macro

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,7 @@ ms(ms('10 hours'), { long: true })    // "10 hours"
 
 ## Related Packages
 
-- [`ms.macro`](https://github.com/knpwrs/ms.macro) - Run `ms` as a macro at build-time.
+- [ms.macro](https://github.com/knpwrs/ms.macro) - Run `ms` as a macro at build-time.
 
 ## Caught a Bug?
 

--- a/readme.md
+++ b/readme.md
@@ -42,6 +42,10 @@ ms(ms('10 hours'), { long: true })    // "10 hours"
 - If a string that contains the number is supplied, it returns it as a number (e.g.: it returns `100` for `'100'`)
 - If you pass a string with a number and a valid unit, the number of equivalent milliseconds is returned
 
+## Related Packages
+
+- [`ms.macro`](https://github.com/knpwrs/ms.macro) - Run `ms` as a macro at build-time.
+
 ## Caught a Bug?
 
 1. [Fork](https://help.github.com/articles/fork-a-repo/) this repository to your own GitHub account and then [clone](https://help.github.com/articles/cloning-a-repository/) it to your local device


### PR DESCRIPTION
A few weeks ago I published a macro version of `ms` that I thought some people may appreciate. This pull request adds a brief "related packages" section.