### PR TITLE
Added options.from

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ module.exports = function(val, options) {
   options = options || {};
   var type = typeof val;
   if (type === 'string' && val.length > 0) {
-    return parse(val);
+    return options.from ? calcFrom(val, options.from) : parse(val);
   } else if (type === 'number' && isNaN(val) === false) {
     return options.long ? fmtLong(val) : fmtShort(val);
   }
@@ -130,11 +130,13 @@ function fmtShort(ms) {
  */
 
 function fmtLong(ms) {
-  return plural(ms, d, 'day') ||
+  return (
+    plural(ms, d, 'day') ||
     plural(ms, h, 'hour') ||
     plural(ms, m, 'minute') ||
     plural(ms, s, 'second') ||
-    ms + ' ms';
+    ms + ' ms'
+  );
 }
 
 /**
@@ -149,4 +151,21 @@ function plural(ms, n, name) {
     return Math.floor(ms / n) + ' ' + name;
   }
   return Math.ceil(ms / n) + ' ' + name + 's';
+}
+
+/**
+ * Calculate the milliseconds for given date
+ * @param  {String} str
+ * @param  {Date} date
+ * @return {Number}
+ * @api private
+ */
+function calcFrom(str, date) {
+  if (new Date(date).toString() === 'Invalid Date' || date === true)
+    throw new Error(
+      'option.from is not a valid Date. options.from=' + JSON.stringify(date)
+    );
+  var ms = parse(str);
+
+  return new Date(date).getTime() + ms;
 }

--- a/tests.js
+++ b/tests.js
@@ -219,3 +219,23 @@ describe('ms(invalid inputs)', function() {
     }).to.throwError();
   });
 });
+
+describe('ms(string, { from: Number })', function() {
+  it('should throw an error when options.from is true', function() {
+    expect(function() {
+      ms('1h', { from: true });
+    }).to.throwError();
+  });
+
+  it('should ignore options.from when it is not Number', function() {
+    expect(ms('1h', { from: '' })).to.be(3600000);
+    expect(ms('1h', { from: NaN })).to.be(3600000);
+  });
+
+  it('should add time to unix epoch time', function() {
+    expect(ms('1ms', { from: new Date(0) })).to.be(1);
+    expect(ms('1s', { from: new Date(0) })).to.be(1000);
+    expect(ms('1m', { from: new Date(0) })).to.be(60000);
+    expect(ms('1h', { from: new Date(0) })).to.be(3600000);
+  });
+});


### PR DESCRIPTION
## WHATSUP
This feature was proposed and discussed in issue #100.

## BEFORE
This was a common pattern in my and others code.
```js
Date.now() + ms('2h')
```

## AFTER
It's super simple now to get the milliseconds of given time.
```js
ms('2h', { from: Date.now() });
```