### PR TITLE
Add default export

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,8 @@ module.exports = function(val, options) {
   );
 };
 
+module.exports.default = module.exports;
+
 /**
  * Parse the given `str` and return milliseconds.
  *


### PR DESCRIPTION
Make ES module - compatible and allow TypeScript users to easily use the package.

This will work after merging the PR:
```ts
import ms from 'ms'
```

I am not a big fan of those double CJS / ES exports myself, but there are a couple of scenarios when you have basically got no other choice.