### PR TITLE
Support expressions with multiple units

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ module.exports = function(val, options) {
   if (type === 'string' && val.length > 0) {
     return val
       .replace(/([0-9])[ \t]+([^ \t])/g, (_, digit, char) => `${digit}${char}`)
+      .trim()
       .split(/[ \t]+/)
       .map(val => parse(val)).reduce((a,b) => a + b);
   } else if (type === 'number' && isNaN(val) === false) {

--- a/index.js
+++ b/index.js
@@ -27,7 +27,10 @@ module.exports = function(val, options) {
   options = options || {};
   var type = typeof val;
   if (type === 'string' && val.length > 0) {
-    return parse(val);
+    return val
+      .replace(/([0-9])[ \t]+([^ \t])/g, (_, digit, char) => `${digit}${char}`)
+      .split(/[ \t]+/)
+      .map(val => parse(val)).reduce((a,b) => a + b);
   } else if (type === 'number' && isNaN(val) === false) {
     return options.long ? fmtLong(val) : fmtShort(val);
   }

--- a/tests.js
+++ b/tests.js
@@ -77,6 +77,18 @@ describe('ms(string)', function() {
   it('should work with negative decimals starting with "."', function() {
     expect(ms('-.5h')).to.be(-1800000);
   });
+
+  it('should work with an expression with multiple units', function() {
+    expect(ms('1h 24m 44s')).to.be(5084000); 
+  });
+
+  it('should work with an expression with multiple units - and allow spaces between digits and units', function() {
+    expect(ms('1 h 24 m  44s 771')).to.be(5084771); 
+  });
+
+  it('should handle trailing whitespace', function() {
+    expect(ms('1 h  ')).to.be(3600000); 
+  });
 });
 
 // long strings


### PR DESCRIPTION
e.g.:
```
ms ('1h 30m') // 5400000
ms('1 h 30 min) //5400000
ms('1  h 50 m 66 s 44ms') //6666044
```
**Logic:**
- first - remove spaces/tabs between last digit and first char of unit.
- then split on space/tab
- then, parse each unit
- and last - sum them up 👍


P.S: good work. love your cleanness, love the tests!
The only thing I might do different is use a strategy pattern instead of a a switch clause.
e.g.
```
//setup, past the "constants" y,m,d,....
types = {}
['y', 'yrs', 'years'....].forEach(label => types[label] = y);
['m','months.... 
['d', 'day', 'days....

//parse - instead of the switch:
return types[type] ? n * types[type] : undefined
```
this is not only faster (it finds the type-value in one check), 
but it can support for example - letting the user pass in custom labels. 

LMK if you're interested - I'll PR for that too 👍 



